### PR TITLE
Fix simplified_fluid calculation

### DIFF
--- a/Testing_1_GasSpeciation.ipynb
+++ b/Testing_1_GasSpeciation.ipynb
@@ -2,19 +2,22 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e7bf7e3d",
+   "id": "13f003c6",
    "metadata": {},
    "source": [
     "# Testing Main Functionality #1: Gas speciation\n",
     "\n",
     "## Goals\n",
-    "1. Take in simplified gas composition and speciate it given P, T, fO2 conditions"
+    "1. Take in simplified fluid composition and speciate it given P, T, fO2 conditions\n",
+    "2. Take in complex fluid composition and speciate it given P, T, fO2 conditions\n",
+    "3. Ensure that an equivalent complex and simplified fluid give the same speciation results\n",
+    "4. Ensure fO2 being held constant at user defined value when a fluid is speciated"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "f74fd72e",
+   "execution_count": 3,
+   "id": "f1b2b23c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,122 +26,208 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "9de2741d",
+   "execution_count": 4,
+   "id": "14eefa1b",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "CO     9.013480e-02\n",
-       "CO2    2.785530e+01\n",
-       "H2     1.249535e-02\n",
-       "H2O    2.852365e+01\n",
-       "H2S    2.029644e+01\n",
-       "S2     7.909392e+00\n",
-       "SO2    1.531258e+01\n",
-       "O2     1.101413e-11\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "spec_comp, input units\n",
+      "CO     4.919336e-02\n",
+      "CO2    1.520274e+01\n",
+      "H2     3.395537e-02\n",
+      "H2O    7.751130e+01\n",
+      "H2S    5.595435e+00\n",
+      "S2     8.003605e-02\n",
+      "SO2    1.527344e+00\n",
+      "O2     1.679701e-11\n",
+      "dtype: float64\n"
+     ]
     }
    ],
    "source": [
     "# create a MagmaticFluid object with a simple gas composition\n",
-    "myfluid = tv.MagmaticFluid(composition={'H2O':49, 'CO2': 35, 'S': 16}, default_units='wtpercent')\n",
+    "myfluid = tv.MagmaticFluid(composition={'H2O':79, 'CO2': 15, 'S': 6}, units='wtpercent', default_units='wtpercent')\n",
     "\n",
     "# speciate given P, T, fO2 conditions\n",
     "specs = tv.calculate_speciation(sample=myfluid, pressure=1000, temperature=1000, fO2_buffer='QFM', fO2_delta=1).result\n",
     "spec_comp = specs.get_composition()\n",
-    "spec_comp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "7bd2ed3b",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "30.703839624481738"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "(spec_comp['S2'] * tv.core.oxideMass[\"S\"]/tv.core.oxideMass[\"S2\"] +\n",
-    " spec_comp['SO2'] * tv.core.oxideMass[\"S\"]/tv.core.oxideMass[\"SO2\"] +\n",
-    " spec_comp['H2S'] * tv.core.oxideMass[\"S\"]/tv.core.oxideMass[\"H2S\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "55e6c511",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "H2O    32.766251\n",
-       "CO2    32.100561\n",
-       "S      35.133188\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "spec_simpl = specs.get_simplified_fluid_composition()\n",
-    "spec_simpl"
+    "print(\"\\n\")\n",
+    "print(\"spec_comp, input units\")\n",
+    "print(spec_comp)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d0b06ab3",
+   "id": "4bebe790",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "S_tot input: 0.03808524856648267\n",
+      "S_tot after speciation: 0.037919328117160735\n",
+      "\n",
+      "\n",
+      "CO2_tot input: 0.06937079614202833\n",
+      "CO2_tot after speciation: 0.06927658241035987\n",
+      "\n",
+      "\n",
+      "H2O_tot input: 0.8925439552914891\n",
+      "H2O_tot after speciation: 0.8928040894724794\n",
+      "\n",
+      "\n",
+      "Input total: 1.0000000000000002\n",
+      "Total after speciation: 1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# # in wt% space\n",
+    "# spec_comp = specs.get_composition(units='wtpercent')\n",
+    "# S_tot = (spec_comp['S2'] * tv.core.oxideMass[\"S\"]/tv.core.oxideMass[\"S2\"] +\n",
+    "#          spec_comp['SO2'] * tv.core.oxideMass[\"S\"]/tv.core.oxideMass[\"SO2\"] +\n",
+    "#          spec_comp['H2S'] * tv.core.oxideMass[\"S\"]/tv.core.oxideMass[\"H2S\"]) # I'm so confused. Do I include this term?\n",
+    "\n",
+    "# # Am I just going crazy and I've calculated the \"tot\" values incorrectly in wt% space? I could try converting\n",
+    "# # to molfraction and doing it mol-wise (e.g., SO2 is one mol S annd one mol O2...)\n",
+    "\n",
+    "# CO2_tot = (spec_comp['CO2'] +\n",
+    "#            spec_comp['CO'] * tv.core.oxideMass[\"CO2\"]/tv.core.oxideMass[\"CO\"])\n",
+    "\n",
+    "# H2O_tot = (spec_comp['H2O'] +\n",
+    "#            spec_comp['H2'] * tv.core.oxideMass[\"H2O\"]/tv.core.oxideMass[\"H2\"] +\n",
+    "#            spec_comp['H2S'] * tv.core.oxideMass[\"H2O\"]/tv.core.oxideMass[\"H2S\"])\n",
+    "\n",
+    "# print(\"S_tot input: \" + str(myfluid.get_composition(species=\"S\")))\n",
+    "# print(\"S_tot after speciation: \" + str(S_tot))\n",
+    "# print(\"\\n\")\n",
+    "# print(\"CO2_tot input: \" + str(myfluid.get_composition(species=\"CO2\")))\n",
+    "# print(\"CO2_tot after speciation: \" + str(CO2_tot))\n",
+    "# print(\"\\n\")\n",
+    "# print(\"H2O_tot input: \" + str(myfluid.get_composition(species=\"H2O\")))\n",
+    "# print(\"H2O_tot after speciation: \" + str(H2O_tot))\n",
+    "# print(\"\\n\")\n",
+    "# print(\"Input total: \" + str(sum(myfluid.get_composition())))\n",
+    "# print(\"Total after speciation: \" + str(S_tot + CO2_tot + H2O_tot))\n",
+    "\n",
+    "# in molfraction space\n",
+    "spec_comp = specs.get_composition(units='molfrac')\n",
+    "S_tot = (spec_comp['S2'] * 2 +\n",
+    "         spec_comp['SO2'] +\n",
+    "         spec_comp['H2S'])\n",
+    "\n",
+    "CO2_tot = (spec_comp['CO2'] +\n",
+    "           spec_comp['CO'])\n",
+    "\n",
+    "H2O_tot = (spec_comp['H2O'] +\n",
+    "           spec_comp['H2'] +\n",
+    "           spec_comp['H2S'])\n",
+    "\n",
+    "recalcd_comp = tv.MagmaticFluid({\"S\": S_tot,\n",
+    "                                 \"CO2\": CO2_tot,\n",
+    "                                 \"H2O\": H2O_tot},\n",
+    "                                 units='molfrac',\n",
+    "                                 default_units='molfrac',\n",
+    "                                 default_normalization='standard')\n",
+    "S_tot = recalcd_comp.get_composition(species=\"S\")\n",
+    "CO2_tot = recalcd_comp.get_composition(species=\"CO2\")\n",
+    "H2O_tot = recalcd_comp.get_composition(species=\"H2O\")\n",
+    "\n",
+    "print(\"S_tot input: \" + str(myfluid.get_composition(species=\"S\", units='molfrac')))\n",
+    "print(\"S_tot after speciation: \" + str(S_tot))\n",
+    "print(\"\\n\")\n",
+    "print(\"CO2_tot input: \" + str(myfluid.get_composition(species=\"CO2\", units='molfrac')))\n",
+    "print(\"CO2_tot after speciation: \" + str(CO2_tot))\n",
+    "print(\"\\n\")\n",
+    "print(\"H2O_tot input: \" + str(myfluid.get_composition(species=\"H2O\", units='molfrac')))\n",
+    "print(\"H2O_tot after speciation: \" + str(H2O_tot))\n",
+    "print(\"\\n\")\n",
+    "print(\"Input total: \" + str(sum(myfluid.get_composition(units='molfrac'))))\n",
+    "print(\"Total after speciation: \" + str(S_tot + CO2_tot + H2O_tot))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4c84194e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "H2O    78.999994\n",
+      "CO2    15.000007\n",
+      "S       5.999999\n",
+      "dtype: float64\n",
+      "100.00000000000001\n"
+     ]
+    }
+   ],
+   "source": [
+    "spec_simpl = specs.get_simplified_fluid_composition()\n",
+    "print(spec_simpl)\n",
+    "print(sum(spec_simpl))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b14c312",
+   "metadata": {},
+   "source": [
+    "Fugacities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8a137233",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'CO': 1.75163077835761,\n",
-       " 'CO2': 230.632074399965,\n",
-       " 'H2': 2.2786474518,\n",
-       " 'H2O': 441.9560551274255,\n",
-       " 'H2S': 207.72964600535423,\n",
+       "{'CO': 0.972348617383240,\n",
+       " 'CO2': 128.026283528372,\n",
+       " 'H2': 6.2979978992,\n",
+       " 'H2O': 1221.5309149875247,\n",
+       " 'H2S': 58.247579333992356,\n",
        " 'O2': 1.286291018879933e-10,\n",
-       " 'S2': 44.120600946,\n",
-       " 'SO2': 84.19940038120089}"
+       " 'S2': 0.45409787711,\n",
+       " 'SO2': 8.542068011858877}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "# Gammas\n",
+    "# Fugacities\n",
     "fugs = tv.calculate_fugacities(sample=myfluid, pressure=1000, temperature=1000, fO2_buffer='QFM', fO2_delta=1,\n",
     "                               opt='gekko').result\n",
     "fugs"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a2b1182d",
+   "metadata": {},
+   "source": [
+    "K values"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "10cb7260",
+   "execution_count": 8,
+   "id": "566a25b1",
    "metadata": {},
    "outputs": [
     {
@@ -150,7 +239,7 @@
        " 'SO2': 98548280692.69196}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -162,19 +251,48 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "0e4b2b89",
+   "cell_type": "markdown",
+   "id": "be4d75ef",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# fugacities"
+    "Fugacity coefficients (gammas)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "65dd0f42",
+   "execution_count": 9,
+   "id": "06af0784",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'CO': 1.2557199322943073,\n",
+       " 'CO2': 1.1766812493927399,\n",
+       " 'H2': 1.1871749799085225,\n",
+       " 'H2O': 0.9013716131009993,\n",
+       " 'H2S': 1.1270119924703847,\n",
+       " 'O2': 1.1900211579833693,\n",
+       " 'S2': 1.1551947347375644,\n",
+       " 'SO2': 1.137584896298915}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# fugacity coefficients (gammas)\n",
+    "\n",
+    "gammas = tv.calculate_fugacity_coefficients(temperature=1000, pressure=1000).result\n",
+    "gammas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "194cfc04",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,25 +301,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "81fe310a",
+   "execution_count": 11,
+   "id": "bf6bf311",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "CO     6.625373e-02\n",
-       "CO2    2.047508e+01\n",
-       "H2     5.116192e-03\n",
-       "H2O    1.167894e+01\n",
-       "H2S    1.774616e+01\n",
-       "S2     2.623952e+01\n",
-       "SO2    2.378893e+01\n",
-       "O2     8.370886e-12\n",
+       "CO     4.919338e-02\n",
+       "CO2    1.520275e+01\n",
+       "H2     3.395537e-02\n",
+       "H2O    7.751129e+01\n",
+       "H2S    5.595434e+00\n",
+       "S2     8.003603e-02\n",
+       "SO2    1.527344e+00\n",
+       "O2     1.679701e-11\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,20 +330,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "483283ea",
+   "execution_count": 12,
+   "id": "3a0181e8",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "H2O    15.831577\n",
-       "CO2    27.843868\n",
-       "S      56.324555\n",
+       "{'CO': 0.972349137277660,\n",
+       " 'CO2': 128.026351981342,\n",
+       " 'H2': 6.2979978166,\n",
+       " 'H2O': 1221.5308989668056,\n",
+       " 'H2S': 58.247571152148005,\n",
+       " 'O2': 1.286291018879933e-10,\n",
+       " 'S2': 0.45409776145,\n",
+       " 'SO2': 8.542066924014495}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fugs2 = tv.calculate_fugacities(sample=specs, pressure=1000, temperature=1000, fO2_buffer='QFM', fO2_delta=1,\n",
+    "                               opt='gekko').result\n",
+    "fugs2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e239a6b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "H2O    78.999988\n",
+       "CO2    15.000014\n",
+       "S       5.999998\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -237,25 +385,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "72949344",
+   "execution_count": 14,
+   "id": "b7438d17",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "CO     4.760210e-02\n",
-       "CO2    1.471098e+01\n",
-       "H2     1.657730e-03\n",
-       "H2O    3.784167e+00\n",
-       "H2S    8.796780e+00\n",
-       "S2     4.562257e+01\n",
-       "SO2    2.703625e+01\n",
-       "O2     6.706009e-12\n",
+       "CO     4.919340e-02\n",
+       "CO2    1.520275e+01\n",
+       "H2     3.395536e-02\n",
+       "H2O    7.751129e+01\n",
+       "H2S    5.595433e+00\n",
+       "S2     8.003600e-02\n",
+       "SO2    1.527344e+00\n",
+       "O2     1.679701e-11\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -268,7 +416,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6faf3b6f",
+   "id": "fe9367fa",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f837c2d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfc27578",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -276,7 +440,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.7 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -291,6 +455,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "40d3a090f54c6569ab1632332b64b2c03c39dcf918b08424e98f38b5ae0af88f"
+   }
   }
  },
  "nbformat": 4,

--- a/Testing_simplified_fluid_issues.ipynb
+++ b/Testing_simplified_fluid_issues.ipynb
@@ -1,0 +1,353 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2417b086",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tavern as tv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ddbee42",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "00b62ecc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "S_tot input: 0.03808524856648267\n",
+      "S_tot after speciation: 0.03808524258993409\n",
+      "\n",
+      "\n",
+      "CO2_tot input: 0.06937079614202833\n",
+      "CO2_tot after speciation: 0.06937083213296716\n",
+      "\n",
+      "\n",
+      "H2O_tot input: 0.8925439552914891\n",
+      "H2O_tot after speciation: 0.8925439252770989\n",
+      "\n",
+      "\n",
+      "Input total: 1.0000000000000002\n",
+      "Total after speciation: 1.0000000000000002\n"
+     ]
+    }
+   ],
+   "source": [
+    "# THIS WORKS!\n",
+    "# create a MagmaticFluid object with a simple gas composition\n",
+    "myfluid = tv.MagmaticFluid(composition={'H2O':79, 'CO2': 15, 'S': 6}, units='wtpercent', default_units='wtpercent')\n",
+    "\n",
+    "# speciate given P, T, fO2 conditions\n",
+    "specs = tv.calculate_speciation(sample=myfluid, pressure=1000, temperature=1000, fO2_buffer='QFM', fO2_delta=1).result\n",
+    "\n",
+    "# in molfraction space -- duplicating what works in calculate_fugacities()\n",
+    "composition_molfrac = specs.get_composition(units='molfrac')\n",
+    "\n",
+    "# first get H, S, C tots\n",
+    "XHtot = (composition_molfrac[\"H2\"] + composition_molfrac[\"H2O\"]*0.6666 +\n",
+    "         composition_molfrac[\"H2S\"]*0.6666)\n",
+    "XStot = (composition_molfrac[\"S2\"] + composition_molfrac[\"H2S\"]*0.3333 +\n",
+    "         composition_molfrac[\"SO2\"]*0.3333)\n",
+    "XCtot = (composition_molfrac[\"CO2\"]*0.3333 + composition_molfrac[\"CO\"]*0.5)\n",
+    "# XOtot = (composition_molfrac[\"H2O\"] * 0.3333 + composition_molfrac[\"SO2\"] * 0.6666 +\n",
+    "#          composition_molfrac[\"CO2\"] * 0.6666 + composition_molfrac[\"CO\"] * 0.5)\n",
+    "\n",
+    "# # normalize H, S, C tots\n",
+    "# HCS_tots = tv.MagmaticFluid({\"H\": XHtot,\n",
+    "#                              \"S\": XStot,\n",
+    "#                              \"C\": XCtot,\n",
+    "#                              \"O\": XOtot},\n",
+    "#                              units='molfrac',\n",
+    "#                              normalization='standard')\n",
+    "\n",
+    "# # then get H2O and CO2 and test returning H2O, CO2, S to match input in myfluid object\n",
+    "# XH2Otot = HCS_tots.get_composition(species=\"H\", units='molfrac') * 0.5\n",
+    "# XCO2tot = HCS_tots.get_composition(species=\"C\", units='molfrac')\n",
+    "\n",
+    "XH2Otot = XHtot * 0.5\n",
+    "XCO2tot = XCtot\n",
+    "\n",
+    "final = tv.MagmaticFluid({\"H2O\": XH2Otot,\n",
+    "                          \"CO2\": XCO2tot,\n",
+    "                          \"S\": XStot},\n",
+    "                          units='molfrac',\n",
+    "                          normalization='standard')\n",
+    "\n",
+    "print(\"S_tot input: \" + str(myfluid.get_composition(species=\"S\", units='molfrac')))\n",
+    "print(\"S_tot after speciation: \" + str(final.get_composition(species=\"S\", units='molfrac')))\n",
+    "print(\"\\n\")\n",
+    "print(\"CO2_tot input: \" + str(myfluid.get_composition(species=\"CO2\", units='molfrac')))\n",
+    "print(\"CO2_tot after speciation: \" + str(final.get_composition(species=\"CO2\", units='molfrac')))\n",
+    "print(\"\\n\")\n",
+    "print(\"H2O_tot input: \" + str(myfluid.get_composition(species=\"H2O\", units='molfrac')))\n",
+    "print(\"H2O_tot after speciation: \" + str(final.get_composition(species=\"H2O\", units='molfrac')))\n",
+    "print(\"\\n\")\n",
+    "print(\"Input total: \" + str(sum(myfluid.get_composition(units='molfrac'))))\n",
+    "print(\"Total after speciation: \" + str(final.get_composition(species=\"S\", units='molfrac') + \n",
+    "                                       final.get_composition(species=\"CO2\", units='molfrac') +\n",
+    "                                       final.get_composition(species=\"H2O\", units='molfrac')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "a71beb18",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "S_tot input: 0.05999999999999999\n",
+      "S_tot after speciation: 0.06000039541598862\n",
+      "\n",
+      "\n",
+      "C_tot input: 0.15\n",
+      "C_tot after speciation: 0.15000001323924742\n",
+      "\n",
+      "\n",
+      "H_tot input: 0.7900000000000001\n",
+      "H_tot after speciation: 0.7899995913447642\n",
+      "\n",
+      "\n",
+      "Input total: 1.0000000000000002\n",
+      "Total after speciation: 0.6014199724576084\n",
+      "H    0.79\n",
+      "C    0.15\n",
+      "S    0.06\n",
+      "dtype: float64\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Now try and go from H, S, C inputs to H, S, C outputs\n",
+    "# create a MagmaticFluid object with a simple gas composition\n",
+    "myfluid = tv.MagmaticFluid(composition={'H':0.79, 'C': 0.15, 'S': 0.06}, units='molfrac', default_units='molfrac')\n",
+    "\n",
+    "# speciate given P, T, fO2 conditions\n",
+    "specs = tv.calculate_speciation(sample=myfluid, pressure=1000, temperature=1000, fO2_buffer='QFM', fO2_delta=1).result\n",
+    "\n",
+    "# in molfraction space -- duplicating what works in calculate_fugacities()\n",
+    "composition_molfrac = specs.get_composition(units='molfrac')\n",
+    "\n",
+    "# first get H, S, C tots\n",
+    "XHtot = (composition_molfrac[\"H2\"] + composition_molfrac[\"H2O\"]*0.6666 +\n",
+    "         composition_molfrac[\"H2S\"]*0.6666)\n",
+    "XStot = (composition_molfrac[\"S2\"] + composition_molfrac[\"H2S\"]*0.3333 +\n",
+    "         composition_molfrac[\"SO2\"]*0.3333)\n",
+    "XCtot = (composition_molfrac[\"CO2\"]*0.3333 + composition_molfrac[\"CO\"]*0.5)\n",
+    "XOtot = (composition_molfrac[\"H2O\"] * 0.3333 + composition_molfrac[\"SO2\"] * 0.6666 +\n",
+    "         composition_molfrac[\"CO2\"] * 0.6666 + composition_molfrac[\"CO\"] * 0.5)\n",
+    "\n",
+    "# normalize H, S, C tots\n",
+    "HCS_tots = tv.MagmaticFluid({\"H\": XHtot,\n",
+    "                             \"S\": XStot,\n",
+    "                             \"C\": XCtot},\n",
+    "                             units='molfrac',\n",
+    "                             default_units='molfrac',\n",
+    "                             normalization='standard')\n",
+    "\n",
+    "print(\"S_tot input: \" + str(myfluid.get_composition(species=\"S\", units='molfrac')))\n",
+    "print(\"S_tot after speciation: \" + str(HCS_tots.get_composition(species=\"S\", units='molfrac')))\n",
+    "print(\"\\n\")\n",
+    "print(\"C_tot input: \" + str(myfluid.get_composition(species=\"C\", units='molfrac')))\n",
+    "print(\"C_tot after speciation: \" + str(HCS_tots.get_composition(species=\"C\")))\n",
+    "print(\"\\n\")\n",
+    "print(\"H_tot input: \" + str(myfluid.get_composition(species=\"H\", units='molfrac')))\n",
+    "print(\"H_tot after speciation: \" + str(HCS_tots.get_composition(species=\"H\")))\n",
+    "print(\"\\n\")\n",
+    "print(\"Input total: \" + str(sum(myfluid.get_composition(units='molfrac'))))\n",
+    "print(\"Total after speciation: \" + str(XStot + XCtot + XHtot))\n",
+    "\n",
+    "print(str(specs.get_simplified_fluid_composition(units='molfrac',\n",
+    "                                                                          H_species='H',\n",
+    "                                                                          C_species='C',\n",
+    "                                                                          S_species='S')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef8abcdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# in molfraction space\n",
+    "spec_comp = specs.get_composition(units='molfrac')\n",
+    "S_tot = (spec_comp['S2'] * 2 +\n",
+    "         spec_comp['SO2'] +\n",
+    "         spec_comp['H2S'])\n",
+    "\n",
+    "CO2_tot = (spec_comp['CO2'] +\n",
+    "           spec_comp['CO'])\n",
+    "\n",
+    "H2O_tot = (spec_comp['H2O'] +\n",
+    "           spec_comp['H2'] +\n",
+    "           spec_comp['H2S'])\n",
+    "\n",
+    "recalcd_comp = tv.MagmaticFluid({\"S\": S_tot,\n",
+    "                                 \"CO2\": CO2_tot,\n",
+    "                                 \"H2O\": H2O_tot},\n",
+    "                                 units='molfrac',\n",
+    "                                 default_units='molfrac',\n",
+    "                                 default_normalization='standard')\n",
+    "S_tot = recalcd_comp.get_composition(species=\"S\")\n",
+    "CO2_tot = recalcd_comp.get_composition(species=\"CO2\")\n",
+    "H2O_tot = recalcd_comp.get_composition(species=\"H2O\")\n",
+    "\n",
+    "print(\"S_tot input: \" + str(myfluid.get_composition(species=\"S\", units='molfrac')))\n",
+    "print(\"S_tot after speciation: \" + str(S_tot))\n",
+    "print(\"\\n\")\n",
+    "print(\"CO2_tot input: \" + str(myfluid.get_composition(species=\"CO2\", units='molfrac')))\n",
+    "print(\"CO2_tot after speciation: \" + str(CO2_tot))\n",
+    "print(\"\\n\")\n",
+    "print(\"H2O_tot input: \" + str(myfluid.get_composition(species=\"H2O\", units='molfrac')))\n",
+    "print(\"H2O_tot after speciation: \" + str(H2O_tot))\n",
+    "print(\"\\n\")\n",
+    "print(\"Input total: \" + str(sum(myfluid.get_composition(units='molfrac'))))\n",
+    "print(\"Total after speciation: \" + str(S_tot + CO2_tot + H2O_tot))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "7fe0168a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CO     2.317292e-02\n",
+       "CO2    7.161369e+00\n",
+       "H2     4.023587e-02\n",
+       "H2O    9.184805e+01\n",
+       "H2S    7.386837e-01\n",
+       "S2     1.093991e-03\n",
+       "SO2    1.873895e-01\n",
+       "O2     1.835461e-11\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "specs.get_composition()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1229fe0f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CO     2.317295e-02\n",
+       "CO2    7.161379e+00\n",
+       "H2     4.023591e-02\n",
+       "H2O    9.184813e+01\n",
+       "H2S    7.386148e-01\n",
+       "S2     1.093785e-03\n",
+       "SO2    1.873719e-01\n",
+       "O2     1.835462e-11\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "specs2 = tv.calculate_speciation(sample=specs, pressure=1000, temperature=1000, fO2_buffer='QFM', fO2_delta=1).result\n",
+    "specs2.get_composition()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d6e0cd6d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CO     2.317298e-02\n",
+       "CO2    7.161388e+00\n",
+       "H2     4.023594e-02\n",
+       "H2O    9.184821e+01\n",
+       "H2S    7.385462e-01\n",
+       "S2     1.093580e-03\n",
+       "SO2    1.873544e-01\n",
+       "O2     1.835463e-11\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "specs3 = tv.calculate_speciation(sample=specs2, pressure=1000, temperature=1000, fO2_buffer='QFM', fO2_delta=1).result\n",
+    "specs3.get_composition()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11cdcb6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "specs3.get_simplified_fluid_composition(units='wtpercent')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd837ee1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tavern/calculate_classes.py
+++ b/tavern/calculate_classes.py
@@ -306,41 +306,35 @@ class calculate_fugacities(Calculate):
         required_species = {"H2O": "H2O", "CO2": "CO2", "S": "S"}
         if set(sample.get_composition().keys()) <= set(required_species.keys()):
             # user has passed a simple composition
-            # composition_molfrac = sample.get_composition(units='molfrac', normalization='standard') 
+            composition_molfrac = sample.get_composition(units='molfrac', normalization='standard') 
 
-            # XH2Otot = composition_molfrac["H2O"]
-            # XCO2tot = composition_molfrac["CO2"]
-            # XStot = composition_molfrac["S"]
-
-            # XHtot_unnorm = XH2Otot * 2
-            # XStot_unnorm = XStot
-            # XCtot_unnorm = XCO2tot
-
-            # # normalize H, S, C tots
-            # HCS_tots = sample_class.MagmaticFluid({"H": XHtot_unnorm,
-            #                                        "S": XStot_unnorm,
-            #                                        "C": XCtot_unnorm},
-            #                                        units='molfrac',
-            #                                        normalization='standard')
-
-            HCS_tots = sample.get_simplified_fluid_composition(H_species="H",
-                                                               C_species="C",
-                                                               S_species="S",
-                                                               units='molfrac',
-                                                               asSampleClass=True)
-            XHtot = HCS_tots.get_composition(species="H", units='molfrac')
-            XStot = HCS_tots.get_composition(species="S", units='molfrac')
-            XCtot = HCS_tots.get_composition(species="C", units='molfrac')
-
-        else: #user passed complex composition
-            composition_molfrac = sample.get_simplified_fluid_composition(units='molfrac',
-                                                                          H_species='H',
-                                                                          C_species='C',
-                                                                          S_species='S')
-
-            XHtot = composition_molfrac["H"]
+            XH2Otot = composition_molfrac["H2O"]
+            XCO2tot = composition_molfrac["CO2"]
             XStot = composition_molfrac["S"]
-            XCtot = composition_molfrac["C"]
+
+            XHtot = XH2Otot * 2
+            XStot = XStot
+            XCtot = XCO2tot
+        
+        elif set(sample.get_composition().keys()) <= set(core.fluid_species_names):
+            # user passed complex composition
+            composition_molfrac = sample.get_composition(units='molfrac')
+
+            # first get H, S, C tots
+            XHtot = (composition_molfrac["H2"] + composition_molfrac["H2O"]*0.6666 +
+                    composition_molfrac["H2S"]*0.6666)
+            XStot = (composition_molfrac["S2"] + composition_molfrac["H2S"]*0.3333 +
+                    composition_molfrac["SO2"]*0.3333)
+            XCtot = (composition_molfrac["CO2"]*0.3333 + composition_molfrac["CO"]*0.5)
+            XOtot = (composition_molfrac["H2O"] * 0.3333 + composition_molfrac["SO2"] * 0.6666 +
+                    composition_molfrac["CO2"] * 0.6666 + composition_molfrac["CO"] * 0.5)
+
+        else: # user passed non-standard simlpified composition
+            composition_molfrac = sample.get_simplified_fluid_composition(units='molfrac')
+
+            XHtot = composition_molfrac["H2O"] * 2
+            XStot = composition_molfrac["S"]
+            XCtot = composition_molfrac["CO2"]
 
         #FIRST calculate fH2 and fS2 using fsolve, two eqns; two unknowns (eqn 9 in Iacovino, 2015)
         # scipy optimize process

--- a/tavern/calculate_classes.py
+++ b/tavern/calculate_classes.py
@@ -305,23 +305,29 @@ class calculate_fugacities(Calculate):
         # check if user is passing a simplified composition
         required_species = {"H2O": "H2O", "CO2": "CO2", "S": "S"}
         if set(sample.get_composition().keys()) <= set(required_species.keys()):
-            composition_molfrac = sample.get_composition(units='molfrac', normalization='standard') 
+            # user has passed a simple composition
+            # composition_molfrac = sample.get_composition(units='molfrac', normalization='standard') 
 
-            XH2Otot = composition_molfrac["H2O"]
-            XCO2tot = composition_molfrac["CO2"]
-            XStot = composition_molfrac["S"]
+            # XH2Otot = composition_molfrac["H2O"]
+            # XCO2tot = composition_molfrac["CO2"]
+            # XStot = composition_molfrac["S"]
 
-            XHtot_unnorm = XH2Otot * 2
-            XStot_unnorm = XStot
-            XCtot_unnorm = XCO2tot
+            # XHtot_unnorm = XH2Otot * 2
+            # XStot_unnorm = XStot
+            # XCtot_unnorm = XCO2tot
 
-            # normalize H, S, C tots
-            HCS_tots = sample_class.MagmaticFluid({"H": XHtot_unnorm,
-                                                   "S": XStot_unnorm,
-                                                   "C": XCtot_unnorm},
-                                                   units='molfrac',
-                                                   normalization='standard')
+            # # normalize H, S, C tots
+            # HCS_tots = sample_class.MagmaticFluid({"H": XHtot_unnorm,
+            #                                        "S": XStot_unnorm,
+            #                                        "C": XCtot_unnorm},
+            #                                        units='molfrac',
+            #                                        normalization='standard')
 
+            HCS_tots = sample.get_simplified_fluid_composition(H_species="H",
+                                                               C_species="C",
+                                                               S_species="S",
+                                                               units='molfrac',
+                                                               asSampleClass=True)
             XHtot = HCS_tots.get_composition(species="H", units='molfrac')
             XStot = HCS_tots.get_composition(species="S", units='molfrac')
             XCtot = HCS_tots.get_composition(species="C", units='molfrac')
@@ -553,9 +559,6 @@ class calculate_fugacities(Calculate):
             # print out all fugacities to check they are sensible
             for k, v in return_dict.items():
                 print("f" + str(k) + ": " + str(v))
-
-        # set object's self.fugacities variable
-        sample.set_fugacities(return_dict)
 
         return return_dict
 

--- a/tavern/sample_class.py
+++ b/tavern/sample_class.py
@@ -274,30 +274,25 @@ class Sample(object):
                 raise core.InputError("The oxide name provided in oxide_masses is not recognised.")
 
         complex_fluid_composition = self.get_composition(units='wtpercent')
-
-        # First, check if fluid is fully speciated
-        if set(complex_fluid_composition.get_composition().keys()) <= set(core.fluid_species_names):
-            # sample is fully speciated
-
         # check if multiple H species are passed or if H is passed as H*tot
         XHtot = 0.0
         if "H" in complex_fluid_composition.keys():
             # assume H is Htot
             XHtot = complex_fluid_composition["H"]
         elif ("H2" in complex_fluid_composition.keys() or
-              "H2O" in complex_fluid_composition.keys() or
-              "H2S" in complex_fluid_composition.keys()):
+            "H2O" in complex_fluid_composition.keys() or
+            "H2S" in complex_fluid_composition.keys()):
             if "H2" in complex_fluid_composition.keys():
                 XHtot = complex_fluid_composition["H2"] * 2
             if "H2O" in complex_fluid_composition.keys():
                 XHtot += (complex_fluid_composition["H2O"] *
-                          core.oxideMass["H"]/core.oxideMass["H2O"])
+                        core.oxideMass["H"]/core.oxideMass["H2O"])
             if "H2S" in complex_fluid_composition.keys():
                 XHtot += (complex_fluid_composition["H2S"] *
-                          core.oxideMass["H"]/core.oxideMass["H2S"])
+                        core.oxideMass["H"]/core.oxideMass["H2S"])
         else:
             pass
-       
+
         # check if multiple C species are passed or if C is passed as C*tot
         XCtot = 0.0
         if "C" in complex_fluid_composition.keys():
@@ -317,16 +312,16 @@ class Sample(object):
             #assume S is Stot
             XStot = complex_fluid_composition["S"]
         elif ("S2" in complex_fluid_composition.keys() or
-              "SO2" in complex_fluid_composition.keys() or
-              "H2S" in complex_fluid_composition.keys()):
+            "SO2" in complex_fluid_composition.keys() or
+            "H2S" in complex_fluid_composition.keys()):
             if "S2" in complex_fluid_composition.keys():
                 XStot = complex_fluid_composition["S2"] * 2
             if "SO2" in complex_fluid_composition.keys():
                 XStot += (complex_fluid_composition["SO2"] *
-                          core.oxideMass["S"]/core.oxideMass["SO2"])
+                        core.oxideMass["S"]/core.oxideMass["SO2"])
             if "H2S" in complex_fluid_composition.keys():
                 XStot += (complex_fluid_composition["H2S"] *
-                          core.oxideMass["S"]/core.oxideMass["H2S"])
+                        core.oxideMass["S"]/core.oxideMass["H2S"])
         else:
             pass
 
@@ -334,6 +329,7 @@ class Sample(object):
                                       "C": XCtot,
                                       "H": XHtot},
                                       units='wtpercent',
+                                      default_units='wtpercent',
                                       default_normalization='standard')
 
         simple_fluid_wtper = pd.Series({})

--- a/tavern/sample_class.py
+++ b/tavern/sample_class.py
@@ -1,3 +1,4 @@
+from email.policy import default
 import pandas as pd
 import warnings as w
 
@@ -264,13 +265,6 @@ class Sample(object):
         pandas.Series or Sample class
             The sample composition, as specified.
         """
-        # Ensure all complex fluid keys are present in sample. If not, add and give value of 0.0
-        for fluidname in core.fluid_species_names:
-            if fluidname in self.get_composition().keys():
-                pass 
-            else:
-                self.change_composition({fluidname: 0.0})
-
         # Process the oxide_masses variable, if necessary:
         oxideMass = copy(core.oxideMass)
         for ox in oxide_masses:
@@ -279,77 +273,104 @@ class Sample(object):
             else:
                 raise core.InputError("The oxide name provided in oxide_masses is not recognised.")
 
-        complex_fluid_composition = self.get_composition(units='molfrac')
-        fl_specs_not_in_comp = []
-        for fluid_spec in core.fluid_species_names:
-            if fluid_spec not in complex_fluid_composition.index:
-                fl_specs_not_in_comp.append(fluid_spec)
-        if len(fl_specs_not_in_comp):
-            w.warn("Warning: " + str(fl_specs_not_in_comp) + " not found in input composition.",
-                   RuntimeWarning, stacklevel=2)
+        complex_fluid_composition = self.get_composition(units='wtpercent')
 
-        # in case Htot is passed
-        try:
+        # First, check if fluid is fully speciated
+        if set(complex_fluid_composition.get_composition().keys()) <= set(core.fluid_species_names):
+            # sample is fully speciated
+
+        # check if multiple H species are passed or if H is passed as H*tot
+        XHtot = 0.0
+        if "H" in complex_fluid_composition.keys():
+            # assume H is Htot
             XHtot = complex_fluid_composition["H"]
-        except:
-            XHtot = (complex_fluid_composition["H2"] + complex_fluid_composition["H2O"]*0.6666 +
-                     complex_fluid_composition["H2S"]*0.6666)
-        # in case Stot is passed
-        try:
-            XStot = complex_fluid_composition["S"]
-        except:
-            XStot = (complex_fluid_composition["S2"] + complex_fluid_composition["H2S"]*0.3333 +
-                     complex_fluid_composition["SO2"]*0.3333)
-        # in case Ctot is passed
-        try:
+        elif ("H2" in complex_fluid_composition.keys() or
+              "H2O" in complex_fluid_composition.keys() or
+              "H2S" in complex_fluid_composition.keys()):
+            if "H2" in complex_fluid_composition.keys():
+                XHtot = complex_fluid_composition["H2"] * 2
+            if "H2O" in complex_fluid_composition.keys():
+                XHtot += (complex_fluid_composition["H2O"] *
+                          core.oxideMass["H"]/core.oxideMass["H2O"])
+            if "H2S" in complex_fluid_composition.keys():
+                XHtot += (complex_fluid_composition["H2S"] *
+                          core.oxideMass["H"]/core.oxideMass["H2S"])
+        else:
+            pass
+       
+        # check if multiple C species are passed or if C is passed as C*tot
+        XCtot = 0.0
+        if "C" in complex_fluid_composition.keys():
+            #assume C is Ctot
             XCtot = complex_fluid_composition["C"]
-        except:
-            XCtot = (complex_fluid_composition["CO2"]*0.3333 + complex_fluid_composition["CO"]*0.5)
-        XOtot = (complex_fluid_composition["H2O"] * 0.3333 +
-                 complex_fluid_composition["SO2"] * 0.6666 +
-                 complex_fluid_composition["CO2"] * 0.6666 + complex_fluid_composition["CO"] * 0.5)
+        elif "CO2" in complex_fluid_composition.keys() or "CO" in complex_fluid_composition.keys():
+            if "CO2" in complex_fluid_composition.keys():
+                XCtot = complex_fluid_composition["CO2"] * core.oxideMass["C"]/core.oxideMass["CO2"]
+            if "CO" in complex_fluid_composition.keys():
+                XCtot += complex_fluid_composition["CO"] * core.oxideMass["C"]/core.oxideMass["CO"]
+        else:
+            pass
+        
+        # check if multiple S species are passed or if S is passed as S*tot
+        XStot = 0.0
+        if "S" in complex_fluid_composition.keys():
+            #assume S is Stot
+            XStot = complex_fluid_composition["S"]
+        elif ("S2" in complex_fluid_composition.keys() or
+              "SO2" in complex_fluid_composition.keys() or
+              "H2S" in complex_fluid_composition.keys()):
+            if "S2" in complex_fluid_composition.keys():
+                XStot = complex_fluid_composition["S2"] * 2
+            if "SO2" in complex_fluid_composition.keys():
+                XStot += (complex_fluid_composition["SO2"] *
+                          core.oxideMass["S"]/core.oxideMass["SO2"])
+            if "H2S" in complex_fluid_composition.keys():
+                XStot += (complex_fluid_composition["H2S"] *
+                          core.oxideMass["S"]/core.oxideMass["H2S"])
+        else:
+            pass
 
         recalcd_comp = MagmaticFluid({"S": XStot,
                                       "C": XCtot,
-                                      "H": XHtot,
-                                      "O": XOtot},
-                                      units='molfrac',
-                                      default_units='molfrac',
+                                      "H": XHtot},
+                                      units='wtpercent',
                                       default_normalization='standard')
 
-        simple_fluid_molfrac = pd.Series({})
+        simple_fluid_wtper = pd.Series({})
         # check which species to return for H, C, and S inventories
-        if H_species == "H2O":
-            simple_fluid_molfrac["H2O"] = recalcd_comp.get_composition(species="H") * 0.5 
-        elif H_species == "H2":
-            simple_fluid_molfrac["H2"] = recalcd_comp.get_composition(species="H") * 0.5
-        elif H_species == "H":
-            simple_fluid_molfrac["H"] = recalcd_comp.get_composition(species="H")
-        else:
+        H_names = ["H2O", "H2"]
+        for h in H_names:
+            if H_species == h:
+                simple_fluid_wtper[h] = (recalcd_comp.get_composition(species="H") *
+                                           core.oxideMass[h]/core.oxideMass["H"])
+        if H_species == "H":
+            simple_fluid_wtper["H"] = recalcd_comp.get_composition(species="H")
+        elif H_species not in H_names:
             raise core.InputError("H_species must be one of 'H2O', 'H2', or 'H'.")
 
-        if C_species == "CO2":
-            simple_fluid_molfrac["CO2"] = recalcd_comp.get_composition(species="C") 
-        elif C_species == "CO":
-            simple_fluid_molfrac["CO"] = recalcd_comp.get_composition(species="C")
-        elif C_species == "C":
-            simple_fluid_molfrac["C"] = recalcd_comp.get_composition(species="C")
-        else:
-            raise core.InputError("C_species must be one of 'CO2' or 'CO'.")
+        C_names = ["CO2", "CO"]
+        for c in C_names:
+            if C_species == c:
+                simple_fluid_wtper[c] = (recalcd_comp.get_composition(species="C") *
+                                           core.oxideMass[c]/core.oxideMass["C"])
+        if C_species == "C":
+            simple_fluid_wtper["C"] = recalcd_comp.get_composition(species="C")
+        elif C_species not in C_names:
+            raise core.InputError("C_species must be one of 'C', 'CO2', or 'CO'.")
 
+        S_names = ["S2", "SO2", "H2S"]
+        for s in S_names:
+            if S_species == s:
+                simple_fluid_wtper[s] = (recalcd_comp.get_composition(species="S") *
+                                           core.oxideMass[s]/core.oxideMass["S"])
         if S_species == "S":
-            simple_fluid_molfrac["S"] = recalcd_comp.get_composition(species="S") 
-        elif S_species == "SO2":
-            simple_fluid_molfrac["SO2"] = recalcd_comp.get_composition(species="S")
-        elif S_species == "H2S":
-            simple_fluid_molfrac["H2S"] = recalcd_comp.get_composition(species="S")
-        elif S_species == "S2":
-            simple_fluid_molfrac["S2"] = recalcd_comp.get_composition(species="S") * 0.5
-        else:
+            simple_fluid_wtper["S"] = recalcd_comp.get_composition(species="S")
+        elif S_species not in S_names:
             raise core.InputError("S_species must be one of 'S', 'SO2', 'H2S', or 'S2'.")
         
-        simple_fluid_composition = MagmaticFluid(simple_fluid_molfrac, units='molfrac',
-                                                 normalization='standard')
+        simple_fluid_composition = MagmaticFluid(simple_fluid_wtper, units='wtpercent',
+                                                 normalization='standard',
+                                                 default_normalization='standard')
 
         # if no units passed, get default
         if units == None:
@@ -367,7 +388,7 @@ class Sample(object):
                                   "or 'molfrac'.")
 
         if asSampleClass is True:
-            return MagmaticFluid(converted)
+            return MagmaticFluid(converted, units='wtpercent')
         else:
             return converted
 
@@ -820,24 +841,6 @@ class MagmaticFluid(Sample):
         self.default_normalization = default_normalization
         self.default_units = default_units
         self.sample_type = 'MagmaticFluid'
-
-    def set_fugacities(self, fugacities):
-        """Sets self.fugacities value for MagmaticFluid object so that they can be retrieved using
-        the get_fugacities() method.
-
-        Parameters
-        ----------
-        fugacities: dict
-            Fugacities of all species.
-
-        Returns
-        -------
-        Pass - sets self.fugacities as dict
-        """
-        self.fugacities = fugacities 
-
-        pass
-
 
 class SilicateMelt(Sample):
     """ A silicate melt major oxide composition. A melt must have the following properties:


### PR DESCRIPTION
Come up with proper, checked standard to calculate a simplified fluid composition, and make this method appropriately provide values to calculate_speciation(). More testing needs to be done on this, but this is a good break point at which to merge changes back into master as it improves upon previous versions significantly.